### PR TITLE
fix: resolve syntax issues in server and pdf indexer

### DIFF
--- a/meu_app/services/pdf_indexer.py
+++ b/meu_app/services/pdf_indexer.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import argparse
 import os, json, time, datetime as dt
 from typing import List, Dict, Any, Optional
 from pathlib import Path
@@ -153,3 +154,15 @@ class PDFIndexer:
 
     def buscar_resposta(self, pergunta: str, *, k: int = 6, max_distance: float = 0.4) -> str:
         return self.buscar_contexto(pergunta, k=k)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Indexador de PDFs")
+    parser.add_argument("--pasta-pdfs", default="data/pdfs")
+    parser.add_argument("--pasta-index", default="index/faiss_index")
+    parser.add_argument("--openai-key", dest="openai_key", default=None)
+    args = parser.parse_args()
+    indexer = PDFIndexer(
+        pasta_pdfs=args.pasta_pdfs, pasta_index=args.pasta_index, openai_key=args.openai_key
+    )
+    print(json.dumps(indexer.indexar_pdfs(), ensure_ascii=False, indent=2))

--- a/server.py
+++ b/server.py
@@ -334,8 +334,7 @@ def health():
 
 @app.route("/metrics")
 def metrics_route():
-    body = (
-         body = "\n".join(
+    body = "\n".join(
         [
             "# HELP app_requests_total Total de requests",
             "# TYPE app_requests_total counter",


### PR DESCRIPTION
## Summary
- fix metrics endpoint construction in `server.py`
- add CLI entrypoint for PDF indexer and ensure proper imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py rebuild-index` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ae8fba9c8329a17a8bbe2f82a943